### PR TITLE
Gifts + bald non-brown eyes

### DIFF
--- a/js/npc/npc.js
+++ b/js/npc/npc.js
@@ -67,30 +67,25 @@ setup.eyesRoll = function(_race, _hair) {
 	var _eyes = 'brown';
 	
 	if (_race = 'white' || _metisRoll <= 30){
-		if (['black', 'brown'].includes(_hair)){
-			if (_eyesRoll <= 5) {
-				_eyes = 'hazel';
-		} else if (_eyesRoll <= 10) {
-			_eyes = 'blue';
-			} else if (_eyesRoll <= 40) {
-			_eyes = 'gray';
-			} else if (_eyesRoll <= 60) {
-				_eyes = 'green';
-			} else {
-				_eyes = 'brown';
-			}
-		}
 		if (['blonde', 'ginger'].includes(_hair)){
 			if (_eyesRoll <= 10) {
-			_eyes = 'brown';
+				_eyes = 'gray';
+			} else if (_eyesRoll <= 25) {
+				_eyes = 'green';
 			} else if (_eyesRoll <= 50) {
-			_eyes = 'blue';
-			} else if (_eyesRoll <= 75) {
-			_eyes = 'hazel';
+				_eyes = 'hazel';
 			} else if (_eyesRoll <= 90) {
-			_eyes = 'green';
-			} else {
-			_eyes = 'gray';
+				_eyes = 'blue';
+			}
+		} else {
+			if (_eyesRoll <= 10) {
+				_eyes = 'gray';
+			} else if (_eyesRoll <= 20) {
+				_eyes = 'green';
+			} else if (_eyesRoll <= 40) {
+				_eyes = 'hazel';
+			} else if (_eyesRoll <= 60) {
+				_eyes = 'blue';
 			}
 		}
 	}

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -187,13 +187,40 @@ setup.perkList = {
 
 setup.gifts = {
     necklace_cheap: {
-        rel: 5
+        rel: 4
     },
     flower: {
-        rel: 1
+        rel: 3
     },
     cosmetics: {
+        rel: 4
+    },
+    tobacco: {
         rel: 3
+    },
+    alcohol: {
+        rel: 3
+    },
+    candy: {
+        rel: 3
+    },
+    soda: {
+        rel: 4
+    },
+    whippit: {
+        rel: 5
+    },
+    xanax: {
+        rel: 5
+    },
+    glue: {
+        rel: 4
+    },
+    plush: {
+        rel: 5
+    },
+    sextoy: {
+        rel: 5
     }
 };
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -224,6 +224,18 @@ setup.gifts = {
     }
 };
 
+setup.getRandomGifts = function (count = 1, exclude) {
+    const _gifts = clone(setup.gifts);
+    if (exclude) {
+        for (let excludeGift in exclude) {
+            delete _gifts[exclude[excludeGift]];
+        }
+    }
+    var shuffledGifts = Object.keys(_gifts).sort((a, b) => 0.5 - Math.random());
+
+    return shuffledGifts.slice(0, count);
+};
+
 setup.inventoryNpc = [
     'knife',
     'bow',

--- a/js/traits.js
+++ b/js/traits.js
@@ -39,7 +39,7 @@ setup.getRandomTraits = function (count = 1, exclude) {
     const _traits = clone(setup.traits);
     if (exclude) {
         for (let excludeTrait in exclude) {
-            delete _gifts[exclude[excludeTrait]];
+            delete _traits[exclude[excludeTrait]];
         }
     }
     var shuffledTraits = Object.keys(_traits).sort((a, b) => 0.5 - Math.random());

--- a/js/traits.js
+++ b/js/traits.js
@@ -39,7 +39,7 @@ setup.getRandomTraits = function (count = 1, exclude) {
     const _traits = clone(setup.traits);
     if (exclude) {
         for (let excludeTrait in exclude) {
-            delete _traits[excludeTrait];
+            delete _gifts[exclude[excludeTrait]];
         }
     }
     var shuffledTraits = Object.keys(_traits).sort((a, b) => 0.5 - Math.random());

--- a/views/farm/Farm - shop.tw
+++ b/views/farm/Farm - shop.tw
@@ -6,7 +6,11 @@
 	  {name:'wood',price:1},
 	  {name:'axe', price:20},
 	  {name:'rope',price:10},
-  ]>>
+	  {name:'alcohol',price:6,sell:false},
+	  {name:'tobacco',price:6,sell:false},
+	  {name:'glue',price:8,sell:false},
+  	  {name:'soda',price:8,sell:false},
+	  ]>>
   <<if $characters.vincent.quests.pregnancy_talked>>
   	<<run $shopItems.push({
 		name: 'milk',
@@ -17,5 +21,3 @@
 <<shop $shopItems 'Farm - shop' '<<if $characters.vincent.relationship < 20>><<set $characters.vincent.relationship++>><</if>>'>>
 <br /><br />
 [[Leave|Farm]]
-
-

--- a/views/game/Inventory items.tw
+++ b/views/game/Inventory items.tw
@@ -173,7 +173,7 @@ Rusty but in good shape knife
 <</item>>
 <<item "cloth" "Cloth">>
 	<<description>>
-		Can craft bandages
+		Can craft bandages and towels
 <</item>>
 <<item "gas_mask" "Gas mask">>
 	<<description>>

--- a/views/game/Inventory items.tw
+++ b/views/game/Inventory items.tw
@@ -125,7 +125,7 @@ Rusty but in good shape knife
 <</item>>
 <<item "necklace_cheap" "Cheap necklace">>
 	<<description>>
-	Can use as a gift (+5 rel)
+	Can use as a gift (+4 rel)
 <</item>>
 <<item "flower" "Flower">>
 	<<description>>
@@ -149,7 +149,7 @@ Rusty but in good shape knife
 <</item>>
 <<item "cosmetics" "Cosmetics">>
 	<<description>>
-	Use to increase girl beauty
+	Use to increase girl beauty or can use as a gift (+4 rel)
 <</item>>
 <<item "growth_potion" "Growth potion">>
 	<<description>>
@@ -173,7 +173,7 @@ Rusty but in good shape knife
 <</item>>
 <<item "cloth" "Cloth">>
 	<<description>>
-		Can craft bandages and towels
+		Can craft bandages
 <</item>>
 <<item "gas_mask" "Gas mask">>
 	<<description>>
@@ -187,4 +187,39 @@ Rusty but in good shape knife
 <<description>>
     Needed for crafting
 <</item>>
-
+<<item "tobacco" "Tobacco">>
+	<<description>>
+	Can use as a gift (+3 rel)
+<</item>>
+<<item "alcohol" "Alcohol">>
+	<<description>>
+	Can use as a gift (+3 rel)
+<</item>>
+<<item "candy" "Candy">>
+	<<description>>
+	Can use as a gift (+3 rel)
+<</item>>
+<<item "soda" "Soda">>
+	<<description>>
+	Can use as a gift (+4 rel)
+<</item>>
+<<item "whippit" "Whippit">>
+	<<description>>
+	Can use as a gift (+5 rel)
+<</item>>
+<<item "xanax" "Xanax">>
+	<<description>>
+	Can use as a gift (+5 rel)
+<</item>>
+<<item "glue" "Glue">>
+	<<description>>
+	Can use as a gift (+4 rel)
+<</item>>
+<<item "plush" "Plush">>
+	<<description>>
+	Can use as a gift (+5 rel)
+<</item>>
+<<item "sextoy" "Sextoy">>
+	<<description>>
+	Can use as a gift (+5 rel)
+<</item>>

--- a/views/npc/Give gift.tw
+++ b/views/npc/Give gift.tw
@@ -21,9 +21,20 @@
 			  <</if>>
 
 			 	<<link 'Gift'>>
-					<<drop $backpack _item 1>>
-					<<set $tmpGirl.gift = true>>
-					<<set $tmpGirl.relationship = Math.min(100, $tmpGirl.relationship + setup.gifts[_item].rel)>>
+					<<set _giftMultiplier = 1>>
+					<<if ($tmpGirl.likes ?? []).includes(_item)>>
+						<<set _giftMultiplier = 3>>
+					<<elseif ($tmpGirl.dislikes ?? []).includes(_item)>>
+						<<set _giftMultiplier = -1>>
+					<</if>>				
+
+					<<if _giftMultiplier >= 1 >>				
+						<<drop $backpack _item 1>>
+						<<set $tmpGirl.gift = true>>
+					<</if>>
+
+					<<set $tmpGirl.relationship = Math.min(100, $tmpGirl.relationship + _giftMultiplier*setup.gifts[_item].rel)>>
+					
 					<<script>>Dialog.close();<</script>>
 					<<script>>state.display(state.active.title, null, "back")<</script>>
 				<</link>>
@@ -44,5 +55,3 @@
 	 flex: 0 0 33.3333%;
 }
 </style>
-
-

--- a/views/npc/NPC info.tw
+++ b/views/npc/NPC info.tw
@@ -51,6 +51,8 @@
 		<span>Eyes: <<=$tmpGirl.eyes>></span>
 				
 		<<if !_unknown && !$charId>>
+			<span>Likes: <<=$tmpGirl.likes>></span>
+			<span>Dislikes: <<=$tmpGirl.dislikes>></span>
 			<span>Personality: <<=$tmpGirl.personality>></span>
 			<span>Gender: <<=setup.genderDescription($tmpGirl)>></span>
 			<span>Orientation: <<=$tmpGirl.orientation>></span>

--- a/views/settlement/Settlement - shop.tw
+++ b/views/settlement/Settlement - shop.tw
@@ -2,16 +2,15 @@
 <h1 class="ptitle">SETTLEMENT SHOP</h1>
 <br /><br />
   <<set $shopItems = [
-	  {name:'necklace_cheap',price:10,sell:false},
-	  {name:'flower',price:5,sell:false},
+  	  {name:'wood',price:1},
 	  {name:'hay',price:1,sell:false},
-	  {name:'wood',price:1},
-	  {name:'piercing',price:10}
+	  {name:'flower',price:6,sell:false},
+	  {name:'candy',price:6,sell:false},
+	  {name:'necklace_cheap',price:8,sell:false},
+	  {name:'plush',price:10,sell:false}
   ]>>
 <<shop $shopItems 'Settlement - shop'>>
 <br /><br />
 <<link 'Leave'>>
 	<<goto 'Settlement'>>
 <</link>>
-
-

--- a/views/underground_city/Underground shop.tw
+++ b/views/underground_city/Underground shop.tw
@@ -10,10 +10,13 @@
 	  {name:'plastic', price: 10, sell: false},
 	  {name:'hair_dye_kit', price: 10},
 	  {name:'buttplug', price: 30},
-	  {name:'cloth', price: 1, buy: false}
+	  {name:'cloth', price: 1, buy: false},
+	  {name:'piercing',price:10},
+	  {name:'cosmetics',price:8,sell:false},
+	  {name:'sextoy',price:10,sell:false},
+	  {name:'whippit',price:10,sell:false},
+	  {name:'xanax',price:10,sell:false}
   ]>>
 <<shop $shopItems 'Underground shop'>>
 <br /><br />
 [[Leave|Underground city]]
-
-

--- a/widgets/npc/newgirl.tw
+++ b/widgets/npc/newgirl.tw
@@ -14,8 +14,9 @@
 		beauty: random(20, 70),
 		birthDate: setup.getBirthDate(_age),
 		relationship: 0,
-		corruption: random(0, 10),
+		corruption: random(0, 50),
 		sub: random(0, 30),
+		happy: random(40, 60),
 		hair: _hair,
 		eyes: _eyes,
 		breasts: either('small', 'medium', 'big'),
@@ -30,6 +31,8 @@
 		orgasms: 0,
 		traits: [],
 		skills: [],
+		likes: [],
+		dislikes: [],
 		personality: setup.personalityTraits(either(1, 2, 2)),
 		endurance: 0,
 		clothes: {
@@ -75,6 +78,10 @@
 <<if setup.percentageChance(50)>>
 	<<set $tmpGirl.skills = setup.getRandomSkills()>>
 <</if>>
+
+<<set $tmpGirl.likes = setup.getRandomGifts(either(1, 2))>>
+<<set $tmpGirl.dislikes = setup.getRandomGifts(either(1, 2), $tmpGirl.likes)>>
+
 <</widget>>
 
 

--- a/widgets/npc/newguy.tw
+++ b/widgets/npc/newguy.tw
@@ -14,7 +14,8 @@
 		birthDate: setup.getBirthDate(_age),
 		relationship: 0,
 		corruption: random(0, 10),
-		sub: random(5, 13),	
+		sub: random(5, 13),
+		happy: random(40, 60),
 		hair: _hair,
 		eyes: _eyes,
 		dick: either('small', 'medium', 'big'),
@@ -27,6 +28,8 @@
 		horny: random(0, 30),
 		traits: [],
 		skills: [],
+		likes: [],
+		dislikes: [],
 		personality: setup.personalityTraits(either(1, 2, 2)),
 		endurance: 0,
 	}>>
@@ -53,6 +56,9 @@
 <</if>>
 
 <<set $tmpGuy.id = setup.generateUniqueKey($tmpGuy)>>
+<<set $tmpGuy.likes = setup.getRandomGifts(either(1, 2))>>
+<<set $tmpGuy.dislikes = setup.getRandomGifts(either(1, 2), $tmpGuy.likes)>>
+
 <</widget>>
 
 

--- a/widgets/npc/newtransgirl.tw
+++ b/widgets/npc/newtransgirl.tw
@@ -1,4 +1,4 @@
-:: Widget newtransgirl [widget] {"position":"975,5475","size":"100,100"}
+:: Widget newtransgirl [widget]
 <<widget newtransgirl>>
 	<<include 'Girl names'>>
 	<<set _age = setup.ageRoll()>>

--- a/widgets/npc/newtransgirl.tw
+++ b/widgets/npc/newtransgirl.tw
@@ -1,4 +1,4 @@
-:: Widget newtransgirl [widget]
+:: Widget newtransgirl [widget] {"position":"975,5475","size":"100,100"}
 <<widget newtransgirl>>
 	<<include 'Girl names'>>
 	<<set _age = setup.ageRoll()>>
@@ -16,6 +16,7 @@
 		relationship: 0,
 		corruption: random(0, 10),
 		sub: random(0, 30),
+		happy: random(40, 60),
 		hair: _hair,
 		eyes: _eyes,
 		breasts: either('small', 'medium', 'big'),
@@ -29,6 +30,8 @@
 		horny: random(0, 30),
 		traits: [],
 		skills: [],
+		likes: [],
+		dislikes: [],
 		personality: setup.personalityTraits(either(1, 2, 2)),
 		endurance: 0,
 		clothes: {
@@ -72,6 +75,10 @@
 <<if setup.percentageChance(50)>>
 	<<set $tmpGirl.skills = setup.getRandomSkills()>>
 <</if>>
+
+<<set $tmpGirl.likes = setup.getRandomGifts(either(1, 2))>>
+<<set $tmpGirl.dislikes = setup.getRandomGifts(either(1, 2), $tmpGirl.likes)>>
+
 <</widget>>
 
 

--- a/widgets/npc/newtransgirl.tw
+++ b/widgets/npc/newtransgirl.tw
@@ -70,7 +70,7 @@
 	<<if setup.percentageChance(30)>>
 		<<set _npcTraits = 2>>
 	<</if>>
-	<<set $tmpGirl.traits = setup.getRandomTraits(_npcTraits, ['breeder'])>>
+	<<set $tmpGirl.traits = setup.getRandomTraits(_npcTraits, ['breeder', 'squiter'])>>
 <</if>>
 <<if setup.percentageChance(50)>>
 	<<set $tmpGirl.skills = setup.getRandomSkills()>>


### PR DESCRIPTION
Mainly changes regarding gifts :
- 9 new gifts, changes on 3 existing to fit better.
- 4 gifts per shop, prices x2 rel bonus (also moved piercing to underground shop with other sex items).
- likes and dislikes and new npc, and display in npc info when known.
- when give gift x3 if likes, x -1 when dislikes (but object not lost) and x1 otherwise.

Misc
- changed the eye roll so 'bald' and 'gray' haired people have a chance to get non-brown eyes (will also impact dyed hair from onLoadSave)
- added to new npc creation : hapiness, tweaked corruption