### PR TITLE
Fix and adjusments to new fuck

### DIFF
--- a/views/npc/fuck/Girl fuck - no.tw
+++ b/views/npc/fuck/Girl fuck - no.tw
@@ -32,9 +32,8 @@ She tells you that you are not her type and hopes you understand.
 <</if>>
 <div id="option2">
   <<link 'Force her'>>
-	  <<set $tmpGirl.relationship -=30>>
+	  <<set $sexForced = true>>
 	  <<fuck $tmpGirl>>
-	  <<set $fuckForced = true>>
   <</link>>
 </div>
 <<link 'Leave'>>

--- a/views/npc/fuck/new/female/buttons.tw
+++ b/views/npc/fuck/new/female/buttons.tw
@@ -61,7 +61,7 @@
 	<</if>>
 		
 <<else>>
-	<<if $player.energy >= 0>>
+	<<if $player.energy >= 5>>
 		<div id="action-buttons">
 		<<for _sexActionKey, _sexAction range _sexActions>>
 			<<capture _sexActionKey, _sexAction>>

--- a/views/npc/fuck/new/female/buttons.tw
+++ b/views/npc/fuck/new/female/buttons.tw
@@ -63,33 +63,33 @@
 	<</if>>
 		
 <<else>>
-	<<if $player.energy >= 5>>
-		<div id="action-buttons">
-		<<for _sexActionKey, _sexAction range _sexActions>>
-			<<capture _sexActionKey, _sexAction>>
-				<<if (_sexAction.show ?? true) && (_actionMax >= _sexAction.minAction || _sexAction.orConditionTrue)>>
-					<<set _linkName = '<span data-balloon-length="medium" data-balloon-pos="up-left" aria-label="' + _sexAction.title + '">[img[setup.ImagePath+"game/misc/actions/"+_sexActionKey+".png"]]</span>'>>
-					<<link _linkName>>
-						<<set $sexAction = _sexActionKey>>
-						<<goto `passage()`>>
-					<</link>>
-				<</if>>
-			<</capture>>
-		<</for>>
-		</div>
+        <<if $player.energy >= 5>>
+            <div id="action-buttons">
+                <<for _sexActionKey, _sexAction range _sexActions>>
+                    <<capture _sexActionKey, _sexAction>>
+                        <<if (_sexAction.show ?? true) && (_actionMax >= _sexAction.minAction || _sexAction.orConditionTrue)>>
+                            <<set _linkName = '<span data-balloon-length="medium" data-balloon-pos="up-left" aria-label="' + _sexAction.title + '">[img[setup.ImagePath+"game/misc/actions/"+_sexActionKey+".png"]]</span>'>>
+                            <<link _linkName>>
+                                <<set $sexAction = _sexActionKey>>
+                                <<goto `passage()`>>
+                            <</link>>
+                        <</if>>
+                    <</capture>>
+                <</for>>
+            </div>
+        <br />
 
-		<br />
+        <<if !$sexForced>>	
+            <<link 'Force her'>>
+                <<set $sexForced = true>>
+                <<unset $sexAction>>
+                <<goto `passage()`>>
+            <</link>>
+        <</if>>	
+     <</if>>
 
-		<<if !$sexForced>>	
-			<<link 'Force her'>>
-				<<set $sexForced = true>>
-				<<unset $sexAction>>
-				<<goto `passage()`>>
-			<</link>>
-		<</if>>	
-	<</if>>	
-    <<link 'End'>>
-	    <<unset $sexAction, $sexForced>>
+     <<link 'End'>>
+	<<unset $sexAction, $sexForced>>
         <<if $oldTmpGirlLocation>>
             <<set $tmpGirl.location = $oldTmpGirlLocation>>
             <<unset $oldTmpGirlLocation>>

--- a/views/npc/fuck/new/female/buttons.tw
+++ b/views/npc/fuck/new/female/buttons.tw
@@ -31,10 +31,10 @@
             <<goto `passage()`>>
         <</link>>
 	<<elseif $sexAction == 'pussy'>>
-		<<link 'Cum in pussy'>>
-			<<set $sexAction = 'cum_in_pussy'>>
-			<<goto `passage()`>>
-		<</link>>
+        <<link 'Cum in pussy'>>
+            <<set $sexAction = 'cum_in_pussy'>>
+            <<goto `passage()`>>
+        <</link>>
         <<link 'Cum on stomatch'>>
             <<set $sexAction = 'cum_on_stomatch'>>
             <<goto `passage()`>>

--- a/views/npc/fuck/new/female/buttons.tw
+++ b/views/npc/fuck/new/female/buttons.tw
@@ -3,16 +3,18 @@
 <<if $sexForced || ($tmpGirl.traits ?? []).includes('nymphomaniac')>>
     <<set _actionMax = 100>>
 <<elseif $tmpGirl.likesGuys>>
-	<<set _actionMax = Math.max($tmpGirl.relationship, $tmpGirl.horny, $tmpGirl.corruption, $tmpGirl.sub)>>
+	<<set _actionMax = Math.max($tmpGirl.relationship, $tmpGirl.horny)>>
+	<<set _actionMax = Math.min(_actionMax, $tmpGirl.corruption)>>
+	<<set _actionMax = Math.max(_actionMax, $tmpGirl.sub)>>
 <<else>>
 	<<set _actionMax = Math.floor($tmpGirl.sub/2)>>
 <</if>>
 
-
 <<if $player.horny >= 100>>
+	<<energy +5>>
 	<<horny_reset>>
 	<<set $player.sexp++>>
-
+	
 	<<if $sexAction == 'handjob'>>
         <<link 'Handjob cum'>>
             <<set $sexAction = 'handjob_cum'>>
@@ -29,10 +31,10 @@
             <<goto `passage()`>>
         <</link>>
 	<<elseif $sexAction == 'pussy'>>
-        <<link 'Cum in pussy'>>
-            <<set $sexAction = 'cum_in_pussy'>>
-            <<goto `passage()`>>
-        <</link>>
+		<<link 'Cum in pussy'>>
+			<<set $sexAction = 'cum_in_pussy'>>
+			<<goto `passage()`>>
+		<</link>>
         <<link 'Cum on stomatch'>>
             <<set $sexAction = 'cum_on_stomatch'>>
             <<goto `passage()`>>
@@ -46,34 +48,46 @@
             <<set $sexAction = 'cum_on_back'>>
             <<goto `passage()`>>
         <</link>>
+	<<elseif _actionMax >= _sexActions['cum_on_face'].minAction>>
+	<<link 'Cum on face'>>
+		<<set $sexAction = 'cum_on_face'>>
+		<<goto `passage()`>>
+	<</link>>
+	<<elseif _actionMax >= _sexActions['cum_in_mouth'].minAction || _sexActions['cum_in_mouth'].orConditionTrue>>
+		<<link 'Cum in mouth'>>
+			<<set $sexAction = 'cum_in_mouth'>>
+			<<goto `passage()`>>
+		<</link>>
 	<</if>>
-    <<link 'Cum on face'>>
-        <<set $sexAction = 'cum_on_face'>>
-        <<goto `passage()`>>
-    <</link>>
-    <<link 'Cum in mouth'>>
-        <<set $sexAction = 'cum_in_mouth'>>
-        <<goto `passage()`>>
-    <</link>>
+		
 <<else>>
-    <div id="action-buttons">
-    <<for _sexActionKey, _sexAction range _sexActions>>
-        <<capture _sexActionKey, _sexAction>>
-            <<if !(_sexAction.show ?? true)>>
-                <<continue>>
-            <</if>>
-            <<set _linkName = '<span data-balloon-length="medium" data-balloon-pos="up-left" aria-label="' + _sexAction.title + '">[img[setup.ImagePath+"game/misc/actions/"+_sexActionKey+".png"]]</span>'>>
-            <<link _linkName>>
-                <<set $sexAction = _sexActionKey>>
-                <<goto `passage()`>>
-            <</link>>
-        <</capture>>
-    <</for>>
-    </div>
+	<<if $player.energy >= 0>>
+		<div id="action-buttons">
+		<<for _sexActionKey, _sexAction range _sexActions>>
+			<<capture _sexActionKey, _sexAction>>
+				<<if (_sexAction.show ?? true) && (_actionMax >= _sexAction.minAction || _sexAction.orConditionTrue)>>
+					<<set _linkName = '<span data-balloon-length="medium" data-balloon-pos="up-left" aria-label="' + _sexAction.title + '">[img[setup.ImagePath+"game/misc/actions/"+_sexActionKey+".png"]]</span>'>>
+					<<link _linkName>>
+						<<set $sexAction = _sexActionKey>>
+						<<goto `passage()`>>
+					<</link>>
+				<</if>>
+			<</capture>>
+		<</for>>
+		</div>
 
-    <br /><br />
+		<br />
 
+		<<if !$sexForced>>	
+			<<link 'Force her'>>
+				<<set $sexForced = true>>
+				<<unset $sexAction>>
+				<<goto `passage()`>>
+			<</link>>
+		<</if>>	
+	<</if>>	
     <<link 'End'>>
+	    <<unset $sexAction, $sexForced>>
         <<if $oldTmpGirlLocation>>
             <<set $tmpGirl.location = $oldTmpGirlLocation>>
             <<unset $oldTmpGirlLocation>>

--- a/views/npc/fuck/new/female/buttons.tw
+++ b/views/npc/fuck/new/female/buttons.tw
@@ -50,14 +50,14 @@
         <</link>>
 	<<elseif _actionMax >= _sexActions['cum_on_face'].minAction>>
 	<<link 'Cum on face'>>
-		<<set $sexAction = 'cum_on_face'>>
-		<<goto `passage()`>>
+	    <<set $sexAction = 'cum_on_face'>>
+	    <<goto `passage()`>>
 	<</link>>
 	<<elseif _actionMax >= _sexActions['cum_in_mouth'].minAction || _sexActions['cum_in_mouth'].orConditionTrue>>
-		<<link 'Cum in mouth'>>
-			<<set $sexAction = 'cum_in_mouth'>>
-			<<goto `passage()`>>
-		<</link>>
+	<<link 'Cum in mouth'>>
+	    <<set $sexAction = 'cum_in_mouth'>>
+	    <<goto `passage()`>>
+	<</link>>
 	<</if>>
 		
 <<else>>

--- a/views/npc/fuck/new/female/buttons.tw
+++ b/views/npc/fuck/new/female/buttons.tw
@@ -48,12 +48,14 @@
             <<set $sexAction = 'cum_on_back'>>
             <<goto `passage()`>>
         <</link>>
-	<<elseif _actionMax >= _sexActions['cum_on_face'].minAction>>
+	<</if>>
+	<<if _actionMax >= _sexActions['cum_on_face'].minAction>>
 	<<link 'Cum on face'>>
 	    <<set $sexAction = 'cum_on_face'>>
 	    <<goto `passage()`>>
 	<</link>>
-	<<elseif _actionMax >= _sexActions['cum_in_mouth'].minAction || _sexActions['cum_in_mouth'].orConditionTrue>>
+	<</if>>
+	<<if _actionMax >= _sexActions['cum_in_mouth'].minAction || _sexActions['cum_in_mouth'].orConditionTrue>>
 	<<link 'Cum in mouth'>>
 	    <<set $sexAction = 'cum_in_mouth'>>
 	    <<goto `passage()`>>

--- a/views/npc/fuck/new/female/fuck.tw
+++ b/views/npc/fuck/new/female/fuck.tw
@@ -34,7 +34,7 @@
         orConditionTrue: ($tmpGirl.traits ?? []).includes('deepthroat'),
         horny: 20,
         maxCorruption: 60,
-        positive: ($tmpGirl.traits ?? []).includes('deepthroat'),
+        positive: (($tmpGirl.traits ?? []).includes('deepthroat') && $tmpGirl.horny <= 79),
         stats: 'dp'
     },
     pussy_lick: {
@@ -75,7 +75,7 @@
     cum_in_mouth: {
         show: false,
         minAction: 45,
-        positive: ($tmpGirl.traits ?? []).includes('cumslut')
+        positive: (($tmpGirl.traits ?? []).includes('cumslut') && $tmpGirl.horny <= 79)
     }
 }>>
 
@@ -122,7 +122,7 @@
 		Her body reacts positively to you. <strong>(Horny + 20)</strong>
 		<br />
 		
-		<<if $tmpGirl.horny >= 100 && !['dp','cum_in_mouth'].includes($sexAction)>>
+		<<if $tmpGirl.horny >= 100>>
 			<<include 'Fuck 2.0 squirt'>>
 			<<=setup.displayName($tmpGirl)>> has an orgasm!<strong> (Happy / Relationship + 5)</strong>
 			<br />

--- a/views/npc/fuck/new/female/fuck.tw
+++ b/views/npc/fuck/new/female/fuck.tw
@@ -5,33 +5,33 @@
         title: 'Handjob',
         minAction: 10,
         horny: 20,
-        maxCorruption: 10
+        maxCorruption: 20
     },
     footjob: {
         title: 'Footjob',
         minAction: 20,
         horny: 20,
-        maxCorruption: 20
+        maxCorruption: 30
     },
     titjob: {
         title: 'Titjob',
-        minAction: 35,
+        minAction: 30,
         show: ['medium', 'big'].includes($tmpGirl.breasts),
         horny: 20,
-        maxCorruption: 35
+        maxCorruption: 40
     },
     bj: {
         title: 'Blowjob',
         minAction: 40,
         orConditionTrue: ($tmpGirl.traits ?? []).includes('cumslut'),
         horny: 20,
-        maxCorruption: 40,
+        maxCorruption: 50,
         stats: 'bj'
     },
     dp: {
         title: 'Deepthroat',
-        minAction: 60,
-        show: ['bj', 'dp'].includes($sexAction),
+        minAction: 50,
+        orConditionTrue: ($tmpGirl.traits ?? []).includes('deepthroat'),
         horny: 20,
         maxCorruption: 60,
         positive: ($tmpGirl.traits ?? []).includes('deepthroat'),
@@ -40,15 +40,14 @@
     pussy_lick: {
         title: 'Lick pussy',
         minAction: 30,
-        horny: 0,
-        maxCorruption: 30,
+        maxCorruption: 40,
         positive: true
     },
     pussy: {
         title: 'Fuck pussy',
         minAction: 50,
         horny: 20,
-        maxCorruption: 50,
+        maxCorruption: 60,
         positive: (!($tmpGirl.traits ?? []).includes('analslut') && !$tmpGirl.virgin),
         pussy: 'pussy'
     },
@@ -56,8 +55,7 @@
         title: 'Finger ass',
         minAction: 60,
         orConditionTrue: ($tmpGirl.traits ?? []).includes('analslut'),
-        horny: 0,
-        maxCorruption: 55,
+        maxCorruption: 70,
         positive: (($tmpGirl.traits ?? []).includes('analslut') && $tmpGirl.anal >= 10),
         stats: 'anal'
     },
@@ -66,12 +64,17 @@
         minAction: 70,
         orConditionTrue: ($tmpGirl.traits ?? []).includes('analslut'),
         horny: 20,
-        maxCorruption: 70,
+        maxCorruption: 80,
         positive: (($tmpGirl.traits ?? []).includes('analslut') && $tmpGirl.anal >= 20),
         stats: 'anal'
     },
+    cum_on_face: {
+        show: false,
+        minAction: 35
+    },
     cum_in_mouth: {
         show: false,
+        minAction: 45,
         positive: ($tmpGirl.traits ?? []).includes('cumslut')
     }
 }>>
@@ -105,31 +108,30 @@
             >>
             She welcomes the attention.<strong> (Happy / Relationship + 1)</strong>
         <</if>>
-         <br /><br />
+         <br />
     <</if>>
 
     <<if (_sexActions[$sexAction] ?? false) && $tmpGirl.corruption < _sexActions[$sexAction].maxCorruption>>
         <<set $tmpGirl.corruption = Math.min($tmpGirl.corruption + 1, 100)>>
 		She is getting more corrupted.<strong> (Corruption + 1)</strong>
-        <br /><br />
+        <br />
     <</if>>
-
 
     <<if (_sexActions[$sexAction] ?? false) && _sexActions[$sexAction].positive>>
         <<set $tmpGirl.horny = Math.min($tmpGirl.horny + 20, 100)>>
 		Her body reacts positively to you. <strong>(Horny + 20)</strong>
-		<br /><br />
+		<br />
+		
+		<<if $tmpGirl.horny >= 100 && !['dp','cum_in_mouth'].includes($sexAction)>>
+			<<include 'Fuck 2.0 squirt'>>
+			<<=setup.displayName($tmpGirl)>> has an orgasm!<strong> (Happy / Relationship + 5)</strong>
+			<br />
+			<<set $tmpGirl.horny = 0,
+				$tmpGirl.orgasms++,
+				$tmpGirl.relationship = Math.min($tmpGirl.relationship + 5, 100),
+				$tmpGirl.happy = Math.min($tmpGirl.happy + 5, 100)>>
+		<</if>>	
     <</if>>
-
-    <<if $tmpGirl.horny >= 100>>
-		<<include 'Fuck 2.0 squirt'>>
-		<<=setup.displayName($tmpGirl)>> has an orgasm!<strong> (Happy / Relationship + 5)</strong>
-		<br /><br />		
-		<<set $tmpGirl.horny = 0,
-			$tmpGirl.orgasms++,
-			$tmpGirl.relationship = Math.min($tmpGirl.relationship + 5, 100),
-			$tmpGirl.happy = Math.min($tmpGirl.happy + 5, 100)>>
-	<</if>>
 
     <<if _sexActions[$sexAction]?.stats>>
         <<set $tmpGirl[_sexActions[$sexAction].stats]++>>
@@ -144,7 +146,5 @@
         <<include 'Fuck 2.0 cum in pussy'>>
 	<</if>>
 <</if>>
-
+<br />
 <<include 'Fuck 2.0 buttons'>>
-
-    

--- a/views/npc/fuck/new/widget.tw
+++ b/views/npc/fuck/new/widget.tw
@@ -1,7 +1,6 @@
 :: Fuck widget [widget]
 
 <<widget fuck>>
-    <<unset $sexAction, $sexForced>>
     <<if !$args[0].gender>>
         <<goto 'Girl fuck 2.0'>>
     <<else>>


### PR DESCRIPTION
Girl fuck no:
 - no need for -30, it is managed by -5 per forced sex action
 - typo sexForced not fuckForced

Buttons:
- the maxActions calculation is in 3 steps because second line is a min, not a max
- energy +5, just before cum, to ensure enough stamina to have the cum sex action displayed
- decided to base cum on face and in mouth display if enough maxAction
- buttons need 5 energy and checked maxAction to display
- included the 'force her' button to switch to forced sex during act to unlock all actions
- the unset is in the end button, otherwise couln't get force to work correctly

Fuck:
- maxCorruption is intended to be 10 more than minAction
- requirements were changed to enable to get to anal (current last action), without needing titjob nor pussy (in case small breast or stay virgin)
- deepthroat, displayed when girl has trait and not depending on previous action (was not fun)
- prevented girls with traits deepthroat and cumslut to orgasm when dp or cum_in_mouth.

Widget
- removed the unset, as I said, worked better in the end button.