### PR TITLE
Vincent shop relationship change

### DIFF
--- a/views/farm/Farm - shop.tw
+++ b/views/farm/Farm - shop.tw
@@ -18,6 +18,11 @@
 		sell: false
 	})>>
   <</if>>
-<<shop 'farm' _shopItems 'Farm - shop' '<<if $characters.vincent.relationship < 20>><<set $characters.vincent.relationship++>><</if>>'>>
+<<shop 'farm' _shopItems 'Farm - shop' '<<if $characters.vincent.relationship < 20>>
+	<<set $characters.vincent.relationship += ($characters.vincent.relationship + _shopItems[_i].qty)>>
+		<<if $characters.vincent.relationship > 20>>
+			<<set $characters.vincent.relationship = 20>>
+		<</if>>
+<</if>>'>>
 <br /><br />
 [[Leave|Farm]]


### PR DESCRIPTION
- Allows the player to gain relationship with Vincent per item purchased, whereas previously no matter how much they bought it'd only increase relationship by 1.
  - If the relationship value that'd occur upon a purchase is greater than 20, $characters.vincent.relationship is set to 20. This is to ensure that the conditions for advancing Vincent's quest are met while preventing the risk of sequence breaking.