### PR TITLE
Update Nursery.tw

### DIFF
--- a/views/cabin/Nursery.tw
+++ b/views/cabin/Nursery.tw
@@ -29,7 +29,8 @@
 			<</if>>
 			<tr class="item">
 				<td style="width: 300px">
-					<<if _nursery.family.mother>>
+					<<set _motherNpc = ''>>
+					<<if (_nursery.family ?? false) && (_nursery.family.mother ?? false)>>
 						<<set _motherNpc = setup.getNpcById(_nursery.family.mother)>>
 					<</if>>
 					<span @class="''+_genderClass+''">


### PR DESCRIPTION
Error triggered if true orphan (no parent record at all), check for ".mother" when ".family" is undefined. Now it checks for ".family" first.  Also clear the motherNpc variable so that the orphan doesn't get the prior kid's mother.