### PR TITLE
Patch 21

### DIFF
--- a/views/explore/Explore event - Wicked family daughter.tw
+++ b/views/explore/Explore event - Wicked family daughter.tw
@@ -122,6 +122,7 @@ Old man notices you and rushes towards you.
 							<<set _daughterAge = randomInteger(19, 24)>>
 							<<set _daughter.birthDate = setup.getBirthDate(_daughterAge)>>
 							<<set _daughter.traits = setup.getRandomTraits(3)>>
+							<<set _daughter.skills = setup.getRandomSkills(0)>>
 							<<set _daughter.virgin = false>>
 
 							<<set _daughter.family = {

--- a/views/explore/Explore event - Wicked family daughter.tw
+++ b/views/explore/Explore event - Wicked family daughter.tw
@@ -190,6 +190,7 @@ Old man notices you and rushes towards you.
 							<<set _daughterAge = randomInteger(19, 24)>>
 							<<set _daughter.birthDate = setup.getBirthDate(_daughterAge)>>
 							<<set _daughter.traits = setup.getRandomTraits(3)>>
+							<<set _daughter.skills = setup.getRandomSkills(0)>>
 							<<set _daughter.virgin = false>>
 
 							<<set _daughter.family = {

--- a/views/explore/Explore event - Wicked family.tw
+++ b/views/explore/Explore event - Wicked family.tw
@@ -207,6 +207,7 @@ Before you can contemplate your next move, a gruff voice pierces the air, and an
                             <<set _daughter.race = 'white'>>
                             <<set _daughter.birthDate = setup.getBirthDate(randomInteger(19, 22))>>
                             <<set _daughter.traits = setup.getRandomTraits(_daughter, 3)>>
+			    <<set _daughter.skills = setup.getRandomSkills(0)>>
                             <<set _daughter.likesGirls = true>>
                             <<if setup.percentageChance(20)>>
                                 <<run _daughter.skills.push('scavenger')>>
@@ -279,6 +280,7 @@ Before you can contemplate your next move, a gruff voice pierces the air, and an
                             <<set _daughter.race = 'white'>>
                             <<set _daughter.birthDate = setup.getBirthDate(randomInteger(19, 22))>>
                             <<set _daughter.traits = setup.getRandomTraits(3)>>
+  			    <<set _daughter.skills = setup.getRandomSkills(0)>>
                             <<set _daughter.virgin = false>>
                             <<set _daughter.likesGirls = true>>
                             <<if setup.percentageChance(20)>>


### PR DESCRIPTION
Fix to both Wicked Family events: Clear the Daughter's skill array before pushing values, to avoid creating doubles.