### PR TITLE
Update Widget - player.tw

### DIFF
--- a/widgets/Widget - player.tw
+++ b/widgets/Widget - player.tw
@@ -351,10 +351,14 @@
 				<<set _siblingLabel = 1>>
 				<<for _familyTreeChildI, _familyTreeChild range _motherNpc.family.kids>>
 					<div>
-					<<set _familyMember = setup.getNpcById(_familyTreeChild)>>
-						<<if _familyMember && $tmpGirl.id != _familyTreeChild>>
+					<<if _familyTreeChild === 'mc'>>
+						You
+					<<elseif _familyTreeChild !== $tmpGirl.id>>
+						<<set _familyMember = setup.getNpcById(_familyTreeChild)>>
+						<<if _familyMember>>
 							<<=_familyMember.name>> (<<=setup.getAge(_familyMember)>>)
 						<</if>>
+					<</if>>
 					</div>
 				<</for>>
 			<</if>>


### PR DESCRIPTION
Fix for error triggered on the child if born from an NPC set as mother (fails to find MC as a sibling).