### PR TITLE
Fixes to remove threesome bugs on male attendant

### DIFF
--- a/views/npc/Attendant - threesome slave choose.tw
+++ b/views/npc/Attendant - threesome slave choose.tw
@@ -2,7 +2,7 @@
 
 <<set _atscEligible = []>>
 <<for _atscI, _atscNpc range $slaves>>
-	<<if setup.getAge(_atscNpc) >= 18 && typeof _atscNpc.sick === 'undefined' && _atscNpc.id !== $tmpGirl.id>>
+	<<if setup.getAge(_atscNpc) >= 18 && typeof _atscNpc.sick === 'undefined' && _atscNpc.id !== $tmpGirl.id && !($tmpGirl.gender === 1 && _atscNpc.gender === 1)>>
 		<<run _atscEligible.push({id: _atscI, npc: _atscNpc})>>
 	<</if>>
 <</for>>
@@ -19,14 +19,33 @@
 				<span @class="_atscGenderClass">
 					<<link _atscNpc2.name>>
 						<<dialogclose>>
-						<<if typeof $slaveId !== 'undefined'>>
+						<<if $tmpGirl.gender === 1>>
+							/* Male attendant: make the female slave the focus NPC */
+							<<set _atscAttNpc = $tmpGirl>>
+							<<set _atscAttGuestId = $guestId>>
+							<<set _atscAttSlaveId = $slaveId>>
+							<<set $tmpGirl = _atscNpc2>>
+							<<set $slaveId = _atscId2>>
+							<<unset $guestId, $charId>>
 							<<set $tmpGirlViewBack = 'NPC view'>>
+							<<set $tmpGirl2 = _atscAttNpc>>
+							<<if typeof _atscAttGuestId !== 'undefined'>>
+								<<set $guestId2 = _atscAttGuestId>>
+								<<unset $slaveId2, $charId2>>
+							<<else>>
+								<<set $slaveId2 = _atscAttSlaveId>>
+								<<unset $guestId2, $charId2>>
+							<</if>>
 						<<else>>
-							<<set $tmpGirlViewBack = 'NPC view - guest'>>
+							<<if typeof $slaveId !== 'undefined'>>
+								<<set $tmpGirlViewBack = 'NPC view'>>
+							<<else>>
+								<<set $tmpGirlViewBack = 'NPC view - guest'>>
+							<</if>>
+							<<set $tmpGirl2 = _atscNpc2>>
+							<<set $slaveId2 = _atscId2>>
+							<<unset $guestId2, $charId2>>
 						<</if>>
-						<<set $tmpGirl2 = _atscNpc2>>
-						<<set $slaveId2 = _atscId2>>
-						<<unset $guestId2, $charId2>>
 						<<threesome $tmpGirl $tmpGirl2>>
 					<</link>>
 				</span>

--- a/views/npc/Attendant fuck choose.tw
+++ b/views/npc/Attendant fuck choose.tw
@@ -5,14 +5,15 @@
 
 <<set _afcMistressIds = setup.getPersonsForLocation($guests, 'mistress')>>
 
+/* Collect fellow attendants; exclude males when the current attendant is male (no MMM support) */
 <<set _afcOtherAtts = []>>
 <<for _afcI range setup.getPersonsForLocation($guests, 'attendant')>>
-	<<if $guests[_afcI].id !== $tmpGirl.id>>
+	<<if $guests[_afcI].id !== $tmpGirl.id && !($tmpGirl.gender === 1 && $guests[_afcI].gender === 1)>>
 		<<run _afcOtherAtts.push({type: 'guest', id: _afcI})>>
 	<</if>>
 <</for>>
 <<for _afcI range setup.getPersonsForLocation($slaves, 'attendant')>>
-	<<if $slaves[_afcI].id !== $tmpGirl.id>>
+	<<if $slaves[_afcI].id !== $tmpGirl.id && !($tmpGirl.gender === 1 && $slaves[_afcI].gender === 1)>>
 		<<run _afcOtherAtts.push({type: 'slave', id: _afcI})>>
 	<</if>>
 <</for>>
@@ -27,14 +28,33 @@
 	<<capture _afcMIdx>>
 		<<set _afcMLink = 'Threesome with Mistress (' + setup.displayName($guests[_afcMIdx]) + ')'>>
 		<<link `_afcMLink`>>
-			<<if typeof $slaveId !== 'undefined'>>
-				<<set $tmpGirlViewBack = 'NPC view'>>
-			<<else>>
+			<<if $tmpGirl.gender === 1>>
+				/* Male attendant: make the mistress the focus NPC */
+				<<set _afcAttNpc = $tmpGirl>>
+				<<set _afcAttGuestId = $guestId>>
+				<<set _afcAttSlaveId = $slaveId>>
+				<<set $tmpGirl = $guests[_afcMIdx]>>
+				<<set $guestId = _afcMIdx>>
+				<<unset $slaveId, $charId>>
+				<<set $tmpGirl2 = _afcAttNpc>>
+				<<if typeof _afcAttGuestId !== 'undefined'>>
+					<<set $guestId2 = _afcAttGuestId>>
+					<<unset $slaveId2, $charId2>>
+				<<else>>
+					<<set $slaveId2 = _afcAttSlaveId>>
+					<<unset $guestId2, $charId2>>
+				<</if>>
 				<<set $tmpGirlViewBack = 'NPC view - guest'>>
+			<<else>>
+				<<if typeof $slaveId !== 'undefined'>>
+					<<set $tmpGirlViewBack = 'NPC view'>>
+				<<else>>
+					<<set $tmpGirlViewBack = 'NPC view - guest'>>
+				<</if>>
+				<<set $tmpGirl2 = $guests[_afcMIdx]>>
+				<<set $guestId2 = _afcMIdx>>
+				<<unset $slaveId2, $charId2>>
 			<</if>>
-			<<set $tmpGirl2 = $guests[_afcMIdx]>>
-			<<set $guestId2 = _afcMIdx>>
-			<<unset $slaveId2, $charId2>>
 			<<threesome $tmpGirl $tmpGirl2>>
 		<</link>>
 	<</capture>>
@@ -46,18 +66,43 @@
 	<<capture _afcOthEntry, _afcOthNpc>>
 		<<set _afcOthLink = 'Threesome with fellow attendant (' + setup.displayName(_afcOthNpc) + ')'>>
 		<<link `_afcOthLink`>>
-			<<if typeof $slaveId !== 'undefined'>>
-				<<set $tmpGirlViewBack = 'NPC view'>>
+			<<if $tmpGirl.gender === 1>>
+				/* Male attendant: make the female fellow attendant the focus NPC */
+				<<set _afcAttNpc = $tmpGirl>>
+				<<set _afcAttGuestId = $guestId>>
+				<<set _afcAttSlaveId = $slaveId>>
+				<<set $tmpGirl = _afcOthNpc>>
+				<<if _afcOthEntry.type === 'guest'>>
+					<<set $guestId = _afcOthEntry.id>>
+					<<unset $slaveId, $charId>>
+					<<set $tmpGirlViewBack = 'NPC view - guest'>>
+				<<else>>
+					<<set $slaveId = _afcOthEntry.id>>
+					<<unset $guestId, $charId>>
+					<<set $tmpGirlViewBack = 'NPC view'>>
+				<</if>>
+				<<set $tmpGirl2 = _afcAttNpc>>
+				<<if typeof _afcAttGuestId !== 'undefined'>>
+					<<set $guestId2 = _afcAttGuestId>>
+					<<unset $slaveId2, $charId2>>
+				<<else>>
+					<<set $slaveId2 = _afcAttSlaveId>>
+					<<unset $guestId2, $charId2>>
+				<</if>>
 			<<else>>
-				<<set $tmpGirlViewBack = 'NPC view - guest'>>
-			<</if>>
-			<<set $tmpGirl2 = _afcOthNpc>>
-			<<if _afcOthEntry.type === 'guest'>>
-				<<set $guestId2 = _afcOthEntry.id>>
-				<<unset $slaveId2, $charId2>>
-			<<else>>
-				<<set $slaveId2 = _afcOthEntry.id>>
-				<<unset $guestId2, $charId2>>
+				<<if typeof $slaveId !== 'undefined'>>
+					<<set $tmpGirlViewBack = 'NPC view'>>
+				<<else>>
+					<<set $tmpGirlViewBack = 'NPC view - guest'>>
+				<</if>>
+				<<set $tmpGirl2 = _afcOthNpc>>
+				<<if _afcOthEntry.type === 'guest'>>
+					<<set $guestId2 = _afcOthEntry.id>>
+					<<unset $slaveId2, $charId2>>
+				<<else>>
+					<<set $slaveId2 = _afcOthEntry.id>>
+					<<unset $guestId2, $charId2>>
+				<</if>>
 			<</if>>
 			<<threesome $tmpGirl $tmpGirl2>>
 		<</link>>

--- a/views/npc/NPC view - guest.tw
+++ b/views/npc/NPC view - guest.tw
@@ -44,7 +44,7 @@
 	<<link `_linkName`>>
 		<<if $tmpGirl.assignedTo === 'attendant' && ($tmpGirl.location === 'shower' || $tmpGirl.location === 'basement')>>
 			<<goto 'Attendant fuck choose'>>
-		<<elseif $tmpGirl.assignedTo === 'mistress' && $tmpGirl.location === 'mistress'>>
+		<<elseif $tmpGirl.assignedTo === 'mistress' && setup.isAtWork($tmpGirl, $weather)>>
 			<<goto 'Mistress fuck choose'>>
 		<<else>>
 			<<goto 'NPC fuck choose'>>
@@ -52,7 +52,7 @@
 	<</link>>
 <</if>>
 
-<<if setup.NpcInHome($tmpGirl)>>
+<<if setup.NpcInHome($tmpGirl) && !(($tmpGirl.assignedTo === 'attendant' || $tmpGirl.assignedTo === 'mistress') && setup.isAtWork($tmpGirl, $weather))>>
 	<<set _linkName = 'Ask '+ _himOrHer +' to fuck someone'>>
 	<<link `_linkName`>>
 		<<addmins 15>>


### PR DESCRIPTION
Changes 3 files:
- NPC view - guest.tw: Remove "Ask to Fuck" from Mistress and Attendant when on duty in basement, since that's based on the guest-house location
- Attendant fuck choose.tw: Don't allow MMM threesome (if both attendants are male).  Threesome with male attendant will automatically focus on Female (since threesome actions don't support male in focus)
- Attendant - threesome fuck choose.tw: Don't include male slaves if the attendant is male (again, no MMM support).