### PR TITLE
Fix attendantStimulate crash when base management not yet unlocked

### DIFF
--- a/js/sleep/processNpc.js
+++ b/js/sleep/processNpc.js
@@ -257,7 +257,7 @@ setup.sleep.processNpc = function(npc, opts) {
                 }
 
                 // Horny: 15% chance to raise by 7-15 if below 80 and stimulation is enabled
-                if ((sv.player.baseManagement.attendantStimulate ?? true) && slaves[ai].horny < 80 && setup.percentageChance(15)) {
+                if ((sv.player.baseManagement?.attendantStimulate ?? true) && slaves[ai].horny < 80 && setup.percentageChance(15)) {
                     let hornyGain = window.randomInteger(7, 15);
                     const slaveAttrToAtt = npc.gender === 0 ? slaves[ai].likesGirls
                                          : npc.gender === 1 ? slaves[ai].likesGuys

--- a/views/cabin/Basement.tw
+++ b/views/cabin/Basement.tw
@@ -87,7 +87,7 @@ Free rooms left: <strong><<=_basementLimitShow>></strong>
 			</center>
 		<</if>>
 		<<set _attVerbs = ['cleaning', 'grooming', 'washing', 'drying off', 'scrubbing', 'rinsing']>>
-		<<if ($player.baseManagement.attendantStimulate ?? true)>>
+		<<if ($player.baseManagement?.attendantStimulate ?? true)>>
 			<<run _attVerbs.push('tickling', 'teasing')>>
 			<<if $slaves.some(s => s.gender === 0 || s.gender === 2)>>
 				<<run _attVerbs.push('fingering')>>


### PR DESCRIPTION
Guard both Basement.tw and processNpc.js reads of
$player.baseManagement.attendantStimulate with optional chaining (?.) so early-game players without base management don't hit a property access error during sleep processing.