### PR TITLE
Fix foursome choose loop capture bug — second partner always loaded l…

### DIFF
--- a/views/npc/NPC foursome choose.tw
+++ b/views/npc/NPC foursome choose.tw
@@ -116,7 +116,7 @@
 									<<set $slaveId3 = _rentry.id>>
 									<<unset $guestId3, $charId3>>
 								<</if>>
-								<<set $tmpGirl3 = _rnpc>>
+								<<set $tmpGirl3 = _rentry.type === 'guest' ? $guests[_rentry.id] : $slaves[_rentry.id]>>
 								<<unset $foursomePickedFirst, $charId, $slaveId>>
 								<<set $tmpGirlViewBack = 'NPC view - guest'>>
 								<<foursome $tmpGirl $tmpGirl2 $tmpGirl3>>


### PR DESCRIPTION
There's a bug in the Foursome choose logic.  When the player tries to choose the second partner, no matter who they choose, it uses the last guest in the array.  This can also (if you play out the scene) replace the selected partner with a copy of the last guest, causing the player to lose an NPC.
The problem is that _rnpc is not captured, so it always contains the last guest in the loop.